### PR TITLE
Fix for non-well formatted issue

### DIFF
--- a/src/Utils/Text.php
+++ b/src/Utils/Text.php
@@ -14,7 +14,7 @@ class Text {
 	 * @return int
 	 */
 	static public function bytesFromHuman($val) {
-		$val = trim($val);
+		$val = intval(trim($val));
 		$last = strtolower($val[strlen($val)-1]);
 		switch($last) {
 			case 'g': $val *= 1024;


### PR DESCRIPTION
$val is a type of string and throws "A non well formed numeric value encountered" exception while multiplying with number. Need to cast it into integer or get integer value before multiply.

Not sure about is it just me because there are no tests (yeah, looking you guys (-.-)). But I'm absolutely sure you need an integer for multiplication. Using valet with php7.1 on macos sierra. 